### PR TITLE
Add Gitpod config

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+tasks:
+  - init: npm install && mvn install -DskipTests=false
+    command: mvn spring-boot:run
+ports:
+  - port: 8080
+    onOpen: open-preview

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# A simple mortgage calculator based on Vaadin 15
+# A simple mortgage calculator based on Vaadin 15 [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/Artur-/mortgage-calculator) 
 
 Provides a single client side view for calculating mortgage rates and a
 button to apply for the mortgage.


### PR DESCRIPTION
Adds a configuration for gitpod to this project, so that it automatically runs the spring boot and does a `mvn clean install` in prebuilds, so users don't need to wait for that.
Also once the webserver is up, the website is automatically opened in the preview.

You can try here: https://gitpod.io/#https://github.com/svenefftinge/mortgage-calculator/tree/svenefftinge/gitpod-setup

P.S.: [this tweet](https://twitter.com/marcenglund/status/1213013127266230274) brought me here


<img width="1349" alt="Screenshot 2020-01-03 at 22 35 49" src="https://user-images.githubusercontent.com/372735/71750646-6e9e2580-2e79-11ea-98e1-0e4d5f778a9c.png">